### PR TITLE
Add support for 2016 RTM

### DIFF
--- a/Configurations/POC-DC-Client-Servers-CORE/DC-Client-Servers-Core.psd1
+++ b/Configurations/POC-DC-Client-Servers-CORE/DC-Client-Servers-Core.psd1
@@ -45,8 +45,18 @@ demonstrations and would need to be modified for your environment.
             Lability_SwitchName = 'LabNet'
             Lability_ProcessorCount = 1
             Lability_StartupMemory = 1GB
-            Lability_Media = '2016TP5_x64_Standard_Core_EN' # Can be Core,Win10,2012R2,nano
-                                                       # 2016TP5_x64_Standard_Core_EN
+            Lability_Media = '2016_x64_Standard_Core_EN_Eval' # Can be Core,Win10,2012R2,nano
+                                                       # 2016_x64_Standard_EN_Eval
+                                                       # 2016_x64_Standard_Core_EN_Eval
+                                                       # 2016_x64_Datacenter_EN_Eval
+                                                       # 2016_x64_Datacenter_Core_EN_Eval
+                                                       # 2016_x64_Standard_Nano_EN_Eval
+                                                       # 2016_x64_Datacenter_Nano_EN_Eval
+                                                       # 2012R2_x64_Standard_EN_Eval
+                                                       # 2012R2_x64_Standard_EN_V5_Eval
+                                                       # 2012R2_x64_Standard_Core_EN_Eval
+                                                       # 2012R2_x64_Standard_Core_EN_V5_Eval
+                                                       # 2012R2_x64_Datacenter_EN_V5_Eval
                                                        # WIN10_x64_Enterprise_EN_Eval
         }
         @{

--- a/Configurations/POC-DC-Client-Servers-CORE/Setup-Lab.ps1
+++ b/Configurations/POC-DC-Client-Servers-CORE/Setup-Lab.ps1
@@ -17,8 +17,11 @@ Write-Host -ForegroundColor Green -Object @"
     
     * Run the lab setup
     Note! If this is the first time you have run this, it can take several
-    hours to downlaod the .ISO's and resources.
+    hours to download the .ISO's and resources.
     This only occurs the first time.
+
+    **Possible problem, if the downloads finish but the script doesn't continue (pauses)
+        Hit the return key once and it will continue
 
     *You will be able to wipe and rebuild this lab without needing to perform
     the downloads again.
@@ -54,7 +57,7 @@ Write-Host -ForegroundColor Yellow -Object 'If this fails, the lab build will fa
 #
 Write-Host -ForegroundColor Cyan -Object 'Building the lab environment'
 # Creates the lab environment without making a Hyper-V Snapshot
-Start-LabConfiguration -ConfigurationData .\*.psd1 -Verbose -path .\ -IgnorePendingReboot -NoSnapshot 
+Start-LabConfiguration -ConfigurationData .\*.psd1 -path .\ -IgnorePendingReboot -NoSnapshot 
 
 Write-Host -ForegroundColor Green -Object @"
 

--- a/Configurations/POC-DC-Client-Servers-GUI/DC-Client-Servers-GUI.psd1
+++ b/Configurations/POC-DC-Client-Servers-GUI/DC-Client-Servers-GUI.psd1
@@ -45,8 +45,18 @@ demonstrations and would need to be modified for your environment.
             Lability_SwitchName = 'LabNet'
             Lability_ProcessorCount = 1
             Lability_StartupMemory = 1GB
-            Lability_Media = '2016TP5_x64_Standard_EN' # Can be Core,Win10,2012R2,nano
-                                                       # 2016TP5_x64_Standard_Core_EN
+            Lability_Media = '2016_x64_Standard_EN_Eval' # Can be Core,Win10,2012R2,nano
+                                                       # 2016_x64_Standard_EN_Eval
+                                                       # 2016_x64_Standard_Core_EN_Eval
+                                                       # 2016_x64_Datacenter_EN_Eval
+                                                       # 2016_x64_Datacenter_Core_EN_Eval
+                                                       # 2016_x64_Standard_Nano_EN_Eval
+                                                       # 2016_x64_Datacenter_Nano_EN_Eval
+                                                       # 2012R2_x64_Standard_EN_Eval
+                                                       # 2012R2_x64_Standard_EN_V5_Eval
+                                                       # 2012R2_x64_Standard_Core_EN_Eval
+                                                       # 2012R2_x64_Standard_Core_EN_V5_Eval
+                                                       # 2012R2_x64_Datacenter_EN_V5_Eval
                                                        # WIN10_x64_Enterprise_EN_Eval
         }
         @{

--- a/Configurations/POC-DC-Client-Servers-GUI/Setup-Lab.ps1
+++ b/Configurations/POC-DC-Client-Servers-GUI/Setup-Lab.ps1
@@ -17,8 +17,11 @@ Write-Host -ForegroundColor Green -Object @"
     
     * Run the lab setup
     Note! If this is the first time you have run this, it can take several
-    hours to downlaod the .ISO's and resources.
+    hours to download the .ISO's and resources.
     This only occurs the first time.
+
+    **Possible problem, if the downloads finish but the script doesn't continue (pauses)
+        Hit the return key once and it will continue
 
     *You will be able to wipe and rebuild this lab without needing to perform
     the downloads again.
@@ -54,7 +57,7 @@ Write-Host -ForegroundColor Yellow -Object 'If this fails, the lab build will fa
 #
 Write-Host -ForegroundColor Cyan -Object 'Building the lab environment'
 # Creates the lab environment without making a Hyper-V Snapshot
-Start-LabConfiguration -ConfigurationData .\*.psd1 -Verbose -path .\ -IgnorePendingReboot -NoSnapshot 
+Start-LabConfiguration -ConfigurationData .\*.psd1 -path .\ -IgnorePendingReboot -NoSnapshot 
 
 Write-Host -ForegroundColor Green -Object @"
 

--- a/Configurations/POC-DCDHCP-Client-Servers-GUI/DCDHCP-Client-Servers-GUI.psd1
+++ b/Configurations/POC-DCDHCP-Client-Servers-GUI/DCDHCP-Client-Servers-GUI.psd1
@@ -57,8 +57,18 @@ demonstrations and would need to be modified for your environment.
             Lability_SwitchName = 'LabNet'
             Lability_ProcessorCount = 1
             Lability_StartupMemory = 1GB
-            Lability_Media = '2016TP5_x64_Standard_EN' # Can be Core,Win10,2012R2,nano
-                                                       # 2016TP5_x64_Standard_Core_EN
+            Lability_Media = '2016_x64_Standard_EN_Eval' # Can be Core,Win10,2012R2,nano
+                                                       # 2016_x64_Standard_EN_Eval
+                                                       # 2016_x64_Standard_Core_EN_Eval
+                                                       # 2016_x64_Datacenter_EN_Eval
+                                                       # 2016_x64_Datacenter_Core_EN_Eval
+                                                       # 2016_x64_Standard_Nano_EN_Eval
+                                                       # 2016_x64_Datacenter_Nano_EN_Eval
+                                                       # 2012R2_x64_Standard_EN_Eval
+                                                       # 2012R2_x64_Standard_EN_V5_Eval
+                                                       # 2012R2_x64_Standard_Core_EN_Eval
+                                                       # 2012R2_x64_Standard_Core_EN_V5_Eval
+                                                       # 2012R2_x64_Datacenter_EN_V5_Eval
                                                        # WIN10_x64_Enterprise_EN_Eval
         }
         @{

--- a/Configurations/POC-DCDHCP-Client-Servers-GUI/Setup-Lab.ps1
+++ b/Configurations/POC-DCDHCP-Client-Servers-GUI/Setup-Lab.ps1
@@ -17,8 +17,11 @@ Write-Host -ForegroundColor Green -Object @"
     
     * Run the lab setup
     Note! If this is the first time you have run this, it can take several
-    hours to downlaod the .ISO's and resources.
+    hours to download the .ISO's and resources.
     This only occurs the first time.
+
+    **Possible problem, if the downloads finish but the script doesn't continue (pauses)
+        Hit the return key once and it will continue
 
     *You will be able to wipe and rebuild this lab without needing to perform
     the downloads again.
@@ -54,7 +57,7 @@ Write-Host -ForegroundColor Yellow -Object 'If this fails, the lab build will fa
 #
 Write-Host -ForegroundColor Cyan -Object 'Building the lab environment'
 # Creates the lab environment without making a Hyper-V Snapshot
-Start-LabConfiguration -ConfigurationData .\*.psd1 -Verbose -path .\ -IgnorePendingReboot -NoSnapshot 
+Start-LabConfiguration -ConfigurationData .\*.psd1 -path .\ -IgnorePendingReboot -NoSnapshot 
 
 Write-Host -ForegroundColor Green -Object @"
 

--- a/Configurations/POC-StandAlone-Server-GUI/Setup-Lab.ps1
+++ b/Configurations/POC-StandAlone-Server-GUI/Setup-Lab.ps1
@@ -17,8 +17,11 @@ Write-Host -ForegroundColor Green -Object @"
     
     * Run the lab setup
     Note! If this is the first time you have run this, it can take several
-    hours to downlaod the .ISO's and resources.
+    hours to download the .ISO's and resources.
     This only occurs the first time.
+
+    **Possible problem, if the downloads finish but the script doesn't continue (pauses)
+        Hit the return key once and it will continue
 
     *You will be able to wipe and rebuild this lab without needing to perform
     the downloads again.
@@ -54,7 +57,7 @@ Write-Host -ForegroundColor Yellow -Object 'If this fails, the lab build will fa
 #
 Write-Host -ForegroundColor Cyan -Object 'Building the lab environment'
 # Creates the lab environment without making a Hyper-V Snapshot
-Start-LabConfiguration -ConfigurationData .\*.psd1 -Verbose -path .\ -IgnorePendingReboot -NoSnapshot 
+Start-LabConfiguration -ConfigurationData .\*.psd1 -path .\ -IgnorePendingReboot -NoSnapshot 
 
 Write-Host -ForegroundColor Green -Object @"
 

--- a/Configurations/POC-StandAlone-Server-GUI/StandAlone-Server-Gui.ps1
+++ b/Configurations/POC-StandAlone-Server-GUI/StandAlone-Server-Gui.ps1
@@ -1,4 +1,4 @@
-Configuration GUILab {
+Configuration AutoLab {
 
     param (
         [Parameter()] 
@@ -125,4 +125,4 @@ Configuration GUILab {
 
 } #end Configuration Example
 
-GUILab -OutputPath .\ -ConfigurationData .\StandAlone-Server-Gui.psd1
+AutoLab -OutputPath .\ -ConfigurationData .\*.psd1

--- a/Configurations/POC-StandAlone-Server-GUI/StandAlone-Server-Gui.psd1
+++ b/Configurations/POC-StandAlone-Server-GUI/StandAlone-Server-Gui.psd1
@@ -15,8 +15,18 @@
             Lability_SwitchName = 'LabNet'
             Lability_ProcessorCount = 2
             Lability_StartupMemory = 2GB
-            Lability_Media = '2016TP5_x64_Standard_EN' # Can be Core,Win10,2012R2,nano
-                                                       # 2016TP5_x64_Standard_Core_EN
+            Lability_Media = '2016_x64_Standard_EN_Eval' # Can be Core,Win10,2012R2,nano
+                                                       # 2016_x64_Standard_EN_Eval
+                                                       # 2016_x64_Standard_Core_EN_Eval
+                                                       # 2016_x64_Datacenter_EN_Eval
+                                                       # 2016_x64_Datacenter_Core_EN_Eval
+                                                       # 2016_x64_Standard_Nano_EN_Eval
+                                                       # 2016_x64_Datacenter_Nano_EN_Eval
+                                                       # 2012R2_x64_Standard_EN_Eval
+                                                       # 2012R2_x64_Standard_EN_V5_Eval
+                                                       # 2012R2_x64_Standard_Core_EN_Eval
+                                                       # 2012R2_x64_Standard_Core_EN_V5_Eval
+                                                       # 2012R2_x64_Datacenter_EN_V5_Eval
                                                        # WIN10_x64_Enterprise_EN_Eval
         }
         @{

--- a/Media.json
+++ b/Media.json
@@ -1,0 +1,620 @@
+[{
+    "Id":  "2016_x64_Standard_EN_Eval",
+    "Filename":  "2016_x64_EN_Eval.iso",
+    "Description":  "Windows Server 2016 Standard 64bit English Evaluation",
+    "Architecture":  "x64",
+    "ImageName":  "Windows Server 2016 SERVERSTANDARD",
+    "MediaType":  "ISO",
+    "OperatingSystem":  "Windows",
+    "Uri":  "http://download.microsoft.com/download/1/6/F/16FA20E6-4662-482A-920B-1A45CF5AAE3C/14393.0.160715-1616.RS1_RELEASE_SERVER_EVAL_X64FRE_EN-US.ISO",
+    "Checksum":  "18A4F00A675B0338F3C7C93C4F131BEB",
+    "CustomData":  {
+        "WindowsOptionalFeature":  ["NetFx3"]
+    },
+    "Hotfixes":  []
+},
+{
+    "Id":  "2016_x64_Standard_Core_EN_Eval",
+    "Filename":  "2016_x64_EN_Eval.iso",
+    "Description":  "Windows Server 2016 Standard Core 64bit English Evaluation",
+    "Architecture":  "x64",
+    "ImageName":  "Windows Server 2016 SERVERSTANDARDCORE",
+    "MediaType":  "ISO",
+    "OperatingSystem":  "Windows",
+    "Uri":  "http://download.microsoft.com/download/1/6/F/16FA20E6-4662-482A-920B-1A45CF5AAE3C/14393.0.160715-1616.RS1_RELEASE_SERVER_EVAL_X64FRE_EN-US.ISO",
+    "Checksum":  "18A4F00A675B0338F3C7C93C4F131BEB",
+    "CustomData":  {
+        "WindowsOptionalFeature":  ["NetFx3"]
+    },
+    "Hotfixes":  []
+},
+{
+    "Id":  "2016_x64_Datacenter_EN_Eval",
+    "Filename":  "2016_x64_EN_Eval.iso",
+    "Description":  "Windows Server 2016 Datacenter 64bit English Evaluation",
+    "Architecture":  "x64",
+    "ImageName":  "Windows Server 2016 SERVERDATACENTER",
+    "MediaType":  "ISO",
+    "OperatingSystem":  "Windows",
+    "Uri":  "http://download.microsoft.com/download/1/6/F/16FA20E6-4662-482A-920B-1A45CF5AAE3C/14393.0.160715-1616.RS1_RELEASE_SERVER_EVAL_X64FRE_EN-US.ISO",
+    "Checksum":  "18A4F00A675B0338F3C7C93C4F131BEB",
+    "CustomData":  {
+        "WindowsOptionalFeature":  ["NetFx3"]
+    },
+    "Hotfixes":  []
+},
+{
+    "Id":  "2016_x64_Datacenter_Core_EN_Eval",
+    "Filename":  "2016_x64_EN_Eval.iso",
+    "Description":  "Windows Server 2016 Datacenter Core 64bit English Evaluation",
+    "Architecture":  "x64",
+    "ImageName":  "Windows Server 2016 SERVERDATACENTERCORE",
+    "MediaType":  "ISO",
+    "OperatingSystem":  "Windows",
+    "Uri":  "http://download.microsoft.com/download/1/6/F/16FA20E6-4662-482A-920B-1A45CF5AAE3C/14393.0.160715-1616.RS1_RELEASE_SERVER_EVAL_X64FRE_EN-US.ISO",
+    "Checksum":  "18A4F00A675B0338F3C7C93C4F131BEB",
+    "CustomData":  {
+        "WindowsOptionalFeature":  ["NetFx3"]
+    },
+    "Hotfixes":  []
+},
+{
+    "Id":  "2016_x64_Standard_Nano_EN_Eval",
+    "Filename":  "2016_x64_EN_Eval.iso",
+    "Description":  "Windows Server 2016 Standard Nano 64bit English Evaluation",
+    "Architecture":  "x64",
+    "ImageName":  "Windows Server 2016 SERVERSTANDARDNANO",
+    "MediaType":  "ISO",
+    "OperatingSystem":  "Windows",
+    "Uri":  "http://download.microsoft.com/download/1/6/F/16FA20E6-4662-482A-920B-1A45CF5AAE3C/14393.0.160715-1616.RS1_RELEASE_SERVER_EVAL_X64FRE_EN-US.ISO",
+    "Checksum":  "18A4F00A675B0338F3C7C93C4F131BEB",
+    "CustomData":  {
+        "SetupComplete":  "CoreCLR",
+        "PackagePath":  "\\NanoServer\\Packages",
+		"PackageLocale": "en-US",
+        "WimPath":  "\\NanoServer\\NanoServer.wim",
+        "Package":  [
+            "Microsoft-NanoServer-Guest-Package",
+            "Microsoft-NanoServer-DSC-Package"
+        ]
+    },
+    "Hotfixes":  []
+},
+{
+    "Id":  "2016_x64_Datacenter_Nano_EN_Eval",
+    "Filename":  "2016_x64_EN_Eval.iso",
+    "Description":  "Windows Server 2016 Datacenter Nano 64bit English Evaluation",
+    "Architecture":  "x64",
+    "ImageName":  "Windows Server 2016 SERVERDATACENTERNANO",
+    "MediaType":  "ISO",
+    "OperatingSystem":  "Windows",
+    "Uri":  "http://download.microsoft.com/download/1/6/F/16FA20E6-4662-482A-920B-1A45CF5AAE3C/14393.0.160715-1616.RS1_RELEASE_SERVER_EVAL_X64FRE_EN-US.ISO",
+    "Checksum":  "18A4F00A675B0338F3C7C93C4F131BEB",
+    "CustomData":  {
+        "SetupComplete":  "CoreCLR",
+        "PackagePath":  "\\NanoServer\\Packages",
+		"PackageLocale": "en-US",
+        "WimPath":  "\\NanoServer\\NanoServer.wim",
+        "Package":  [
+            "Microsoft-NanoServer-Guest-Package",
+            "Microsoft-NanoServer-DSC-Package"
+        ]
+    },
+    "Hotfixes":  []
+},
+{
+	"Id": "2012R2_x64_Standard_EN_Eval",
+    "Filename": "2012R2_x64_EN_Eval.iso",
+    "Description": "Windows Server 2012 R2 Standard 64bit English Evaluation",
+    "Architecture": "x64",
+    "ImageName": "Windows Server 2012 R2 SERVERSTANDARD",
+	"MediaType": "ISO",
+    "OperatingSystem": "Windows",
+	"Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
+	"Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
+	"CustomData": {
+		"WindowsOptionalFeature": ["NetFx3"]
+	},
+    "Hotfixes": [
+		{
+			"Id": "Windows8.1-KB2883200-x64.msu",
+			"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2883200-x64.msu"
+		},
+		{
+			"Id": "Windows8.1-KB2894029-x64.msu",
+			"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894029-x64.msu"
+		},
+		{
+			"Id": "Windows8.1-KB2894179-x64.msu",
+			"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894179-x64.msu"
+		},
+		{
+			"Id": "Windows8.1-KB3003057-x64.msu",
+			"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3003057-x64.msu"
+		},
+    	{
+			"Id": "Windows8.1-KB3000850-x64.msu",
+			"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3000850-x64.msu"
+		},
+		{
+			"Id": "Windows8.1-KB3014442-x64.msu",
+			"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3014442-x64.msu"
+		},
+		{
+			"Id": "Windows8.1-KB3016437-x64.msu",
+			"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3016437-x64.msu"
+		}
+	]
+},
+{
+	"Id": "2012R2_x64_Standard_EN_V5_Eval",
+    "Filename": "2012R2_x64_EN_Eval.iso",
+    "Description": "Windows Server 2012 R2 Standard 64bit English Evaluation with WMF 5",
+    "Architecture": "x64",
+    "ImageName": "Windows Server 2012 R2 SERVERSTANDARD",
+	"MediaType": "ISO",
+    "OperatingSystem": "Windows",
+	"Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
+	"Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
+	"CustomData": {
+		"WindowsOptionalFeature": ["NetFx3"]
+	},
+    "Hotfixes": [
+		{
+			"Id": "Win8.1AndW2K12R2-KB3134758-x64.msu",
+			"Uri": "https://download.microsoft.com/download/2/C/6/2C6E1B4A-EBE5-48A6-B225-2D2058A9CEFB/Win8.1AndW2K12R2-KB3134758-x64.msu"
+		}
+	]
+},
+{
+	"Id": "2012R2_x64_Standard_Core_EN_Eval",
+    "Filename": "2012R2_x64_EN_Eval.iso",
+    "Description": "Windows Server 2012 R2 Standard Core 64bit English Evaluation",
+    "Architecture": "x64",
+    "ImageName": "Windows Server 2012 R2 SERVERSTANDARDCORE",
+	"MediaType": "ISO",
+    "OperatingSystem": "Windows",
+	"Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
+	"Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
+	"CustomData": {
+		"WindowsOptionalFeature": ["NetFx3"]
+	},
+    "Hotfixes": [
+		{
+			"Id": "Windows8.1-KB2883200-x64.msu",
+			"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2883200-x64.msu"
+		},
+		{
+			"Id": "Windows8.1-KB2894029-x64.msu",
+			"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894029-x64.msu"
+		},
+		{
+			"Id": "Windows8.1-KB2894179-x64.msu",
+			"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894179-x64.msu"
+		},
+		{
+			"Id": "Windows8.1-KB3003057-x64.msu",
+			"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3003057-x64.msu"
+		},
+    	{
+			"Id": "Windows8.1-KB3000850-x64.msu",
+			"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3000850-x64.msu"
+		},
+		{
+			"Id": "Windows8.1-KB3014442-x64.msu",
+			"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3014442-x64.msu"
+		},
+		{
+			"Id": "Windows8.1-KB3016437-x64.msu",
+			"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3016437-x64.msu"
+		}
+	]
+},
+{
+	"Id": "2012R2_x64_Standard_Core_EN_V5_Eval",
+    "Filename": "2012R2_x64_EN_Eval.iso",
+    "Description": "Windows Server 2012 R2 Standard Core 64bit English Evaluation with WMF 5",
+    "Architecture": "x64",
+    "ImageName": "Windows Server 2012 R2 SERVERSTANDARDCORE",
+	"MediaType": "ISO",
+    "OperatingSystem": "Windows",
+	"Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
+	"Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
+	"CustomData": {
+		"WindowsOptionalFeature": ["NetFx3"]
+	},
+    "Hotfixes": [
+		{
+			"Id": "Win8.1AndW2K12R2-KB3134758-x64.msu",
+			"Uri": "https://download.microsoft.com/download/2/C/6/2C6E1B4A-EBE5-48A6-B225-2D2058A9CEFB/Win8.1AndW2K12R2-KB3134758-x64.msu"
+		}
+	]
+},
+{
+	"Id": "2012R2_x64_Datacenter_EN_Eval",
+    "Filename": "2012R2_x64_EN_Eval.iso",
+    "Description": "Windows Server 2012 R2 Datacenter 64bit English Evaluation",
+    "Architecture": "x64",
+	"ImageName": "Windows Server 2012 R2 SERVERDATACENTER",
+	"MediaType": "ISO",
+    "OperatingSystem": "Windows",
+	"Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
+	"Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
+	"CustomData": {
+		"WindowsOptionalFeature": ["NetFx3"]
+	},
+    "Hotfixes": [
+		{
+			"Id": "Windows8.1-KB2883200-x64.msu",
+			"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2883200-x64.msu"
+		},
+		{
+			"Id": "Windows8.1-KB2894029-x64.msu",
+			"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894029-x64.msu"
+		},
+		{
+			"Id": "Windows8.1-KB2894179-x64.msu",
+			"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894179-x64.msu"
+		},
+		{
+			"Id": "Windows8.1-KB3003057-x64.msu",
+			"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3003057-x64.msu"
+		},
+    	{
+			"Id": "Windows8.1-KB3000850-x64.msu",
+			"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3000850-x64.msu"
+		},
+		{
+			"Id": "Windows8.1-KB3014442-x64.msu",
+			"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3014442-x64.msu"
+		},
+		{
+			"Id": "Windows8.1-KB3016437-x64.msu",
+			"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3016437-x64.msu"
+		}
+	]
+},
+{
+	"Id": "2012R2_x64_Datacenter_EN_V5_Eval",
+    "Filename": "2012R2_x64_EN_Eval.iso",
+    "Description": "Windows Server 2012 R2 Datacenter 64bit English Evaluation with WMF 5",
+    "Architecture": "x64",
+	"ImageName": "Windows Server 2012 R2 SERVERDATACENTER",
+	"MediaType": "ISO",
+    "OperatingSystem": "Windows",
+	"Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
+	"Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
+	"CustomData": {
+		"WindowsOptionalFeature": ["NetFx3"]
+	},
+    "Hotfixes": [
+		{
+			"Id": "Win8.1AndW2K12R2-KB3134758-x64.msu",
+			"Uri": "https://download.microsoft.com/download/2/C/6/2C6E1B4A-EBE5-48A6-B225-2D2058A9CEFB/Win8.1AndW2K12R2-KB3134758-x64.msu"
+		}
+	]
+},
+{
+	"Id": "2012R2_x64_Datacenter_Core_EN_Eval",
+    "Filename": "2012R2_x64_EN_Eval.iso",
+    "Description": "Windows Server 2012 R2 Datacenter Core 64bit English Evaluation",
+    "Architecture": "x64",
+	"ImageName": "Windows Server 2012 R2 SERVERDATACENTERCORE",
+	"MediaType": "ISO",
+    "OperatingSystem": "Windows",
+	"Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
+	"Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
+	"CustomData": {
+		"WindowsOptionalFeature": ["NetFx3"]
+	},
+    "Hotfixes": [
+		{
+			"Id": "Windows8.1-KB2883200-x64.msu",
+			"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2883200-x64.msu"
+		},
+		{
+			"Id": "Windows8.1-KB2894029-x64.msu",
+			"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894029-x64.msu"
+		},
+		{
+			"Id": "Windows8.1-KB2894179-x64.msu",
+			"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894179-x64.msu"
+		},
+		{
+			"Id": "Windows8.1-KB3003057-x64.msu",
+			"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3003057-x64.msu"
+		},
+    	{
+			"Id": "Windows8.1-KB3000850-x64.msu",
+			"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3000850-x64.msu"
+		},
+		{
+			"Id": "Windows8.1-KB3014442-x64.msu",
+			"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3014442-x64.msu"
+		},
+		{
+			"Id": "Windows8.1-KB3016437-x64.msu",
+			"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3016437-x64.msu"
+		}
+	]
+},
+{
+	"Id": "2012R2_x64_Datacenter_Core_EN_V5_Eval",
+    "Filename": "2012R2_x64_EN_Eval.iso",
+    "Description": "Windows Server 2012 R2 Datacenter Core 64bit English Evaluation with WMF 5",
+    "Architecture": "x64",
+	"ImageName": "Windows Server 2012 R2 SERVERDATACENTERCORE",
+	"MediaType": "ISO",
+    "OperatingSystem": "Windows",
+	"Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
+	"Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
+	"CustomData": {
+		"WindowsOptionalFeature": ["NetFx3"]
+	},
+    "Hotfixes": [
+		{
+			"Id": "Win8.1AndW2K12R2-KB3134758-x64.msu",
+			"Uri": "https://download.microsoft.com/download/2/C/6/2C6E1B4A-EBE5-48A6-B225-2D2058A9CEFB/Win8.1AndW2K12R2-KB3134758-x64.msu"
+		}
+	]
+},
+{
+	"Id": "WIN81_x64_Enterprise_EN_Eval",
+    "Filename": "WIN81_x64_ENT_EN_Eval.iso",
+    "Description": "Windows 8.1 64bit Enterprise English Evaluation",
+	"Architecture": "x64",
+	"ImageName": "Windows 8.1 Enterprise Evaluation",
+	"MediaType": "ISO",
+    "OperatingSystem": "Windows",
+	"Uri": "http://download.microsoft.com/download/B/9/9/B999286E-0A47-406D-8B3D-5B5AD7373A4A/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_ENTERPRISE_EVAL_EN-US-IR3_CENA_X64FREE_EN-US_DV9.ISO",
+	"Checksum": "EE63618E3BE220D86B993C1ABBCF32EB",
+    "CustomData": {
+		"WindowsOptionalFeature": ["NetFx3"],
+		"CustomBootstrap": [
+			"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
+			"NET USER Administrator /active:yes;",
+			"Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope LocalMachine -Force;",
+			"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
+			"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
+		]
+	},
+    "Hotfixes": [
+		{
+			"Id": "Windows8.1-KB2883200-x64.msu",
+			"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2883200-x64.msu"
+		},
+		{
+			"Id": "Windows8.1-KB2894029-x64.msu",
+			"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894029-x64.msu"
+		},
+		{
+			"Id": "Windows8.1-KB2894179-x64.msu",
+			"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894179-x64.msu"
+		},
+		{
+			"Id": "Windows8.1-KB3003057-x64.msu",
+			"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3003057-x64.msu"
+		},
+    	{
+			"Id": "Windows8.1-KB3000850-x64.msu",
+			"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3000850-x64.msu"
+		},
+		{
+			"Id": "Windows8.1-KB3014442-x64.msu",
+			"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3014442-x64.msu"
+		},
+		{
+			"Id": "Windows8.1-KB3016437-x64.msu",
+			"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3016437-x64.msu"
+		}
+	]
+},
+{
+	"Id": "WIN81_x64_Enterprise_EN_V5_Eval",
+    "Filename": "WIN81_x64_ENT_EN_Eval.iso",
+    "Description": "Windows 8.1 64bit Enterprise English Evaluation with WMF 5",
+	"Architecture": "x64",
+	"ImageName": "Windows 8.1 Enterprise Evaluation",
+	"MediaType": "ISO",
+    "OperatingSystem": "Windows",
+	"Uri": "http://download.microsoft.com/download/B/9/9/B999286E-0A47-406D-8B3D-5B5AD7373A4A/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_ENTERPRISE_EVAL_EN-US-IR3_CENA_X64FREE_EN-US_DV9.ISO",
+	"Checksum": "EE63618E3BE220D86B993C1ABBCF32EB",
+    "CustomData": {
+		"WindowsOptionalFeature": ["NetFx3"],
+		"CustomBootstrap": [
+			"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
+			"NET USER Administrator /active:yes;",
+			"Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope LocalMachine -Force;",
+			"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
+			"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
+		]
+	},
+    "Hotfixes": [
+		{
+			"Id": "Win8.1AndW2K12R2-KB3134758-x64.msu",
+			"Uri": "https://download.microsoft.com/download/2/C/6/2C6E1B4A-EBE5-48A6-B225-2D2058A9CEFB/Win8.1AndW2K12R2-KB3134758-x64.msu"
+		}
+	]
+},
+{
+	"Id": "WIN81_x86_Enterprise_EN_Eval",
+    "Filename": "WIN81_x86_ENT_EN_Eval.iso",
+    "Description": "Windows 8.1 32bit Enterprise English Evaluation",
+	"Architecture": "x86",
+	"ImageName": "Windows 8.1 Enterprise Evaluation",
+	"MediaType": "ISO",
+    "OperatingSystem": "Windows",
+	"Uri": "http://download.microsoft.com/download/B/9/9/B999286E-0A47-406D-8B3D-5B5AD7373A4A/9600.17050.WINBLUE_REFRESH.140317-1640_X86FRE_ENTERPRISE_EVAL_EN-US-IR3_CENA_X86FREE_EN-US_DV9.ISO",
+	"Checksum": "B2ACCD5F135C3EEDE256D398856AEEAD",
+    "CustomData": {
+		"WindowsOptionalFeature": ["NetFx3"],
+		"CustomBootstrap": [
+			"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
+			"NET USER Administrator /active:yes;",
+			"Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope LocalMachine -Force;",
+			"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
+			"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
+		]
+	},
+    "Hotfixes": [
+		{
+			"Id": "Windows8.1-KB2883200-x86.msu",
+			"Uri": "http://download.microsoft.com/download/6/F/C/6FC4B3F3-1103-452F-929D-A9FCABF1AD2B/Windows8.1-KB2883200-x86.msu"
+		},
+		{
+			"Id": "Windows8.1-KB2894029-x86.msu",
+			"Uri": "http://download.microsoft.com/download/6/F/C/6FC4B3F3-1103-452F-929D-A9FCABF1AD2B/Windows8.1-KB2894029-x86.msu"
+		},
+		{
+			"Id": "Windows8.1-KB2894179-x86.msu",
+			"Uri": "http://download.microsoft.com/download/6/F/C/6FC4B3F3-1103-452F-929D-A9FCABF1AD2B/Windows8.1-KB2894179-x86.msu"
+		},
+		{
+			"Id": "Windows8.1-KB3003057-x86.msu",
+			"Uri": "http://download.microsoft.com/download/A/5/1/A51119A7-729B-4800-844C-189E2BDCFF85/Windows8.1-KB3003057-x86.msu"
+		},
+    	{
+			"Id": "Windows8.1-KB3000850-x86.msu",
+			"Uri": "http://download.microsoft.com/download/A/5/1/A51119A7-729B-4800-844C-189E2BDCFF85/Windows8.1-KB3000850-x86.msu"
+		},
+		{
+			"Id": "Windows8.1-KB3014442-x86.msu",
+			"Uri": "http://download.microsoft.com/download/A/5/1/A51119A7-729B-4800-844C-189E2BDCFF85/Windows8.1-KB3014442-x86.msu"
+		}
+	]
+},
+{
+	"Id": "WIN81_x86_Enterprise_EN_V5_Eval",
+    "Filename": "WIN81_x86_ENT_EN_Eval.iso",
+    "Description": "Windows 8.1 32bit Enterprise English Evaluation with WMF 5",
+	"Architecture": "x86",
+	"ImageName": "Windows 8.1 Enterprise Evaluation",
+	"MediaType": "ISO",
+    "OperatingSystem": "Windows",
+	"Uri": "http://download.microsoft.com/download/B/9/9/B999286E-0A47-406D-8B3D-5B5AD7373A4A/9600.17050.WINBLUE_REFRESH.140317-1640_X86FRE_ENTERPRISE_EVAL_EN-US-IR3_CENA_X86FREE_EN-US_DV9.ISO",
+	"Checksum": "B2ACCD5F135C3EEDE256D398856AEEAD",
+    "CustomData": {
+		"WindowsOptionalFeature": ["NetFx3"],
+		"CustomBootstrap": [
+			"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
+			"NET USER Administrator /active:yes;",
+			"Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope LocalMachine -Force;",
+			"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
+			"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
+		]
+	},
+    "Hotfixes": [
+		{
+			"Id": "Win8.1-KB3134758-x86.msu",
+			"Uri": "https://download.microsoft.com/download/2/C/6/2C6E1B4A-EBE5-48A6-B225-2D2058A9CEFB/Win8.1-KB3134758-x86.msu"
+		}
+	]
+},
+{
+	"Id": "WIN10_x64_Enterprise_EN_Eval",
+    "Filename": "WIN10_x64_ENT_EN_RS1_Eval.iso",
+    "Description": "Windows 10 64bit Enterprise 1607 English Evaluation",
+	"Architecture": "x64",
+	"ImageName": "Windows 10 Enterprise Evaluation",
+	"MediaType": "ISO",
+    "OperatingSystem": "Windows",
+	"Uri": "http://download.microsoft.com/download/2/5/4/254230E8-AEA5-43C5-94F6-88CE222A5846/14393.0.160715-1616.RS1_RELEASE_CLIENTENTERPRISEEVAL_OEMRET_X64FRE_EN-US.ISO",
+	"Checksum": "482B970A9892CDC1D0E69372A9E430D7",
+    "CustomData": {
+		"WindowsOptionalFeature": ["NetFx3"],
+		"CustomBootstrap": [
+			"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
+			"NET USER Administrator /active:yes;",
+			"Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope LocalMachine -Force;",
+			"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
+			"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
+		]
+	},
+    "Hotfixes": [
+		{
+			"Id": "windows10.0-kb3176495-x64_a344b21f039bfc4c4c145af471da86005fa4288f.msu",
+			"Uri": "http://download.windowsupdate.com/d/msdownload/update/software/secu/2016/08/windows10.0-kb3176495-x64_a344b21f039bfc4c4c145af471da86005fa4288f.msu"
+		}
+	]
+},
+{
+	"Id": "WIN10_x86_Enterprise_EN_Eval",
+    "Filename": "WIN10_x86_ENT_RS1_EN_Eval.iso",
+    "Description": "Windows 10 32bit Enterprise 1607 English Evaluation",
+	"Architecture": "x86",
+	"ImageName": "Windows 10 Enterprise Evaluation",
+	"MediaType": "ISO",
+    "OperatingSystem": "Windows",
+	"Uri": "http://download.microsoft.com/download/2/5/4/254230E8-AEA5-43C5-94F6-88CE222A5846/14393.0.160715-1616.RS1_RELEASE_CLIENTENTERPRISEEVAL_OEMRET_X64FRE_EN-US.ISO",
+	"Checksum": "50978CE784D0BC5921D0E89AF00C9361",
+    "CustomData": {
+		"WindowsOptionalFeature": ["NetFx3"],
+		"CustomBootstrap": [
+			"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
+			"NET USER Administrator /active:yes;",
+			"Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope LocalMachine -Force;",
+			"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
+			"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
+		]
+	},
+    "Hotfixes": [
+		{
+			"Id": "windows10.0-kb3176495-x86_53681ca9d2e5efe55370591ba5fa5f3ff973219d.msu",
+			"Uri": "http://download.windowsupdate.com/d/msdownload/update/software/secu/2016/08/windows10.0-kb3176495-x86_53681ca9d2e5efe55370591ba5fa5f3ff973219d.msu"
+		}
+	]
+},
+{
+	"Id": "WIN10_x64_Enterprise_LTSB_EN_Eval",
+    "Filename": "WIN10_x64_ENT_LTSB_EN_Eval.iso",
+    "Description": "Windows 10 64bit Enterprise LTSB English Evaluation",
+	"Architecture": "x64",
+	"ImageName": "Windows 10 Enterprise Evaluation",
+	"MediaType": "ISO",
+    "OperatingSystem": "Windows",
+	"Uri": "http://download.microsoft.com/download/C/3/9/C399EEA8-135D-4207-92C9-6AAB3259F6EF/10240.16384.150709-1700.TH1_CLIENTENTERPRISEEVAL_OEMRET_X64FRE_EN-US.ISO",
+	"Checksum": "6CD2F47F2C32FAA7BE85F1DC81AF3220",
+    "CustomData": {
+		"WindowsOptionalFeature": ["NetFx3"],
+		"CustomBootstrap": [
+			"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
+			"NET USER Administrator /active:yes;",
+			"Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope LocalMachine -Force;",
+			"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
+			"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
+		]
+	},
+    "Hotfixes": [
+ 		{
+ 			"Id": "windows10.0-kb3176492-x64_ec5bb377bb4509739664c17d094362c5cb41ef9b.msu",
+ 			"Uri": "http://download.windowsupdate.com/d/msdownload/update/software/secu/2016/08/windows10.0-kb3176492-x64_ec5bb377bb4509739664c17d094362c5cb41ef9b.msu"
+ 		}
+ 	]
+},
+{
+	"Id": "WIN10_x86_Enterprise_LTSB_EN_Eval",
+    "Filename": "WIN10_x86_ENT_LTSB_EN_Eval.iso",
+    "Description": "Windows 10 32bit Enterprise LTSB English Evaluation",
+	"Architecture": "x86",
+	"ImageName": "Windows 10 Enterprise Evaluation",
+	"MediaType": "ISO",
+    "OperatingSystem": "Windows",
+	"Uri": "http://download.microsoft.com/download/C/3/9/C399EEA8-135D-4207-92C9-6AAB3259F6EF/10240.16384.150709-1700.TH1_CLIENTENTERPRISEEVAL_OEMRET_X86FRE_EN-US.ISO",
+	"Checksum": "5531E6EE40A69E22A7386864A9087CDD",
+    "CustomData": {
+		"WindowsOptionalFeature": ["NetFx3"],
+		"CustomBootstrap": [
+			"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
+			"NET USER Administrator /active:yes;",
+			"Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope LocalMachine -Force;",
+			"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
+			"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
+		]
+	},
+    "Hotfixes": [
+ 		{
+ 			"Id": "windows10.0-kb3176492-x86_56d8fdac3036f4db96471c208fc3d9b8876760e3.msu",
+ 			"Uri": "http://download.windowsupdate.com/c/msdownload/update/software/secu/2016/08/windows10.0-kb3176492-x86_56d8fdac3036f4db96471c208fc3d9b8876760e3.msu"
+ 		}
+ 	]
+}]

--- a/Setup-Host.ps1
+++ b/Setup-Host.ps1
@@ -66,7 +66,7 @@ Copy-item -Path C:\PS-AutoLab-Env\Configurations\* -recurse -Destination C:\Labi
 
 #### Temp fix until Lability updates version with new media File
 #### Copying new media file manually
-Copy-item -Path C:\PS-AutoLab-Env\media.json -Destination C:\lability\Config
+Copy-item -Path C:\PS-AutoLab-Env\media.json -Destination 'C:\Program Files\WindowsPowershell\Modules\Lability\0.10.0\config'
 
 
 Write-Host -ForegroundColor Green -Object @"

--- a/Setup-Host.ps1
+++ b/Setup-Host.ps1
@@ -38,15 +38,6 @@ else {
     Write-Host -ForegroundColor Cyan -Object "Adding $add to TrustedHosts"
     Set-Item -Path WSMan:\localhost\Client\TrustedHosts -Value $add -Concatenate -force
 }
-<#
-If ($trust.value -eq "" -or $trust.value -eq "*"){
-    Set-Item -Path WSMan:\localhost\Client\TrustedHosts -Value * -Force
-} Else {
-    Write-Warning "Your system is not a default installation -- "
-    Write-Warning "Your trustedhosts has a value $($trust.Value)"
-    break
-}
-#>
 
 # Lability install
 Write-Host -ForegroundColor Cyan "Installing Lability for the lab build"
@@ -72,6 +63,10 @@ If ($HostStatus -eq $False) {
 ###### COPY Configs to host machine
 Write-Host -ForegroundColor Cyan -Object "Copying configs to c:\Lability\Configurations" 
 Copy-item -Path C:\PS-AutoLab-Env\Configurations\* -recurse -Destination C:\Lability\Configurations -force
+
+#### Temp fix until Lability updates version with new media File
+#### Copying new media file manually
+Copy-item -Path C:\PS-AutoLab-Env\media.json -Destination C:\lability\Config
 
 
 Write-Host -ForegroundColor Green -Object @"

--- a/Setup-Host.ps1
+++ b/Setup-Host.ps1
@@ -42,7 +42,7 @@ else {
 # Lability install
 Write-Host -ForegroundColor Cyan "Installing Lability for the lab build"
 Get-PackageSource -Name PSGallery | Set-PackageSource -Trusted -Force -ForceBootstrap
-Install-Module -Name Lability -RequiredVersion 0.10.0
+Install-Module -Name Lability -RequiredVersion 0.10.0 -Force
 
 # Installing modules to host(Author) machine need to run configs - this will be replaced
 # In the next build - will auto-read from Cofniguration File

--- a/Standalone/POC-DC-Client-Servers-CORE/DC-Client-Servers-Core.psd1
+++ b/Standalone/POC-DC-Client-Servers-CORE/DC-Client-Servers-Core.psd1
@@ -45,8 +45,18 @@ demonstrations and would need to be modified for your environment.
             Lability_SwitchName = 'LabNet'
             Lability_ProcessorCount = 1
             Lability_StartupMemory = 1GB
-            Lability_Media = '2016TP5_x64_Standard_Core_EN' # Can be Core,Win10,2012R2,nano
-                                                       # 2016TP5_x64_Standard_Core_EN
+            Lability_Media = '2016_x64_Standard_Core_EN_Eval' # Can be Core,Win10,2012R2,nano
+                                                       # 2016_x64_Standard_EN_Eval
+                                                       # 2016_x64_Standard_Core_EN_Eval
+                                                       # 2016_x64_Datacenter_EN_Eval
+                                                       # 2016_x64_Datacenter_Core_EN_Eval
+                                                       # 2016_x64_Standard_Nano_EN_Eval
+                                                       # 2016_x64_Datacenter_Nano_EN_Eval
+                                                       # 2012R2_x64_Standard_EN_Eval
+                                                       # 2012R2_x64_Standard_EN_V5_Eval
+                                                       # 2012R2_x64_Standard_Core_EN_Eval
+                                                       # 2012R2_x64_Standard_Core_EN_V5_Eval
+                                                       # 2012R2_x64_Datacenter_EN_V5_Eval
                                                        # WIN10_x64_Enterprise_EN_Eval
         }
         @{

--- a/Standalone/POC-DC-Client-Servers-GUI/DC-Client-Servers-GUI.psd1
+++ b/Standalone/POC-DC-Client-Servers-GUI/DC-Client-Servers-GUI.psd1
@@ -45,8 +45,18 @@ demonstrations and would need to be modified for your environment.
             Lability_SwitchName = 'LabNet'
             Lability_ProcessorCount = 1
             Lability_StartupMemory = 1GB
-            Lability_Media = '2016TP5_x64_Standard_EN' # Can be Core,Win10,2012R2,nano
-                                                       # 2016TP5_x64_Standard_Core_EN
+            Lability_Media = '2016_x64_Standard_EN_Eval' # Can be Core,Win10,2012R2,nano
+                                                       # 2016_x64_Standard_EN_Eval
+                                                       # 2016_x64_Standard_Core_EN_Eval
+                                                       # 2016_x64_Datacenter_EN_Eval
+                                                       # 2016_x64_Datacenter_Core_EN_Eval
+                                                       # 2016_x64_Standard_Nano_EN_Eval
+                                                       # 2016_x64_Datacenter_Nano_EN_Eval
+                                                       # 2012R2_x64_Standard_EN_Eval
+                                                       # 2012R2_x64_Standard_EN_V5_Eval
+                                                       # 2012R2_x64_Standard_Core_EN_Eval
+                                                       # 2012R2_x64_Standard_Core_EN_V5_Eval
+                                                       # 2012R2_x64_Datacenter_EN_V5_Eval
                                                        # WIN10_x64_Enterprise_EN_Eval
         }
         @{

--- a/Standalone/POC-DCDHCP-Client-Servers-GUI/DCDHCP-Client-Servers-GUI.psd1
+++ b/Standalone/POC-DCDHCP-Client-Servers-GUI/DCDHCP-Client-Servers-GUI.psd1
@@ -57,8 +57,18 @@ demonstrations and would need to be modified for your environment.
             Lability_SwitchName = 'LabNet'
             Lability_ProcessorCount = 1
             Lability_StartupMemory = 1GB
-            Lability_Media = '2016TP5_x64_Standard_EN' # Can be Core,Win10,2012R2,nano
-                                                       # 2016TP5_x64_Standard_Core_EN
+            Lability_Media = '2016_x64_Standard_EN_Eval' # Can be Core,Win10,2012R2,nano
+                                                       # 2016_x64_Standard_EN_Eval
+                                                       # 2016_x64_Standard_Core_EN_Eval
+                                                       # 2016_x64_Datacenter_EN_Eval
+                                                       # 2016_x64_Datacenter_Core_EN_Eval
+                                                       # 2016_x64_Standard_Nano_EN_Eval
+                                                       # 2016_x64_Datacenter_Nano_EN_Eval
+                                                       # 2012R2_x64_Standard_EN_Eval
+                                                       # 2012R2_x64_Standard_EN_V5_Eval
+                                                       # 2012R2_x64_Standard_Core_EN_Eval
+                                                       # 2012R2_x64_Standard_Core_EN_V5_Eval
+                                                       # 2012R2_x64_Datacenter_EN_V5_Eval
                                                        # WIN10_x64_Enterprise_EN_Eval
         }
         @{

--- a/Standalone/POC-StandAlone-Server-GUI/StandAlone-Server-Gui.psd1
+++ b/Standalone/POC-StandAlone-Server-GUI/StandAlone-Server-Gui.psd1
@@ -15,8 +15,18 @@
             Lability_SwitchName = 'LabNet'
             Lability_ProcessorCount = 2
             Lability_StartupMemory = 2GB
-            Lability_Media = '2016TP5_x64_Standard_EN' # Can be Core,Win10,2012R2,nano
-                                                       # 2016TP5_x64_Standard_Core_EN
+            Lability_Media = '2016_x64_Standard_EN_Eval' # Can be Core,Win10,2012R2,nano
+                                                       # 2016_x64_Standard_EN_Eval
+                                                       # 2016_x64_Standard_Core_EN_Eval
+                                                       # 2016_x64_Datacenter_EN_Eval
+                                                       # 2016_x64_Datacenter_Core_EN_Eval
+                                                       # 2016_x64_Standard_Nano_EN_Eval
+                                                       # 2016_x64_Datacenter_Nano_EN_Eval
+                                                       # 2012R2_x64_Standard_EN_Eval
+                                                       # 2012R2_x64_Standard_EN_V5_Eval
+                                                       # 2012R2_x64_Standard_Core_EN_Eval
+                                                       # 2012R2_x64_Standard_Core_EN_V5_Eval
+                                                       # 2012R2_x64_Datacenter_EN_V5_Eval
                                                        # WIN10_x64_Enterprise_EN_Eval
         }
         @{


### PR DESCRIPTION
This also removed support for 2016 TP5 - as this is a breaking change, the Major version number must be incremented on Release
Also modified psd1s for new media types.