### PR TITLE
Use $PSScriptRoot as the source directory 

### DIFF
--- a/ReadMe.MD
+++ b/ReadMe.MD
@@ -50,9 +50,9 @@ type to Hyper-V(Unsupported) or the Host hyper-v will not work!
 
 # Instructions 
 1. Download the ZIP of this repository to the Host computer.
-2. Extract the zip of PS-AutoLab-Env to your C:\ drive (C:\PS-AutoLab-Env)
-3. Open PowerShell with administrative privileges
-4. Change to folder C:\PS-Auto-Lab-Env
+2. Extract the folder PS-AutoLab-Env from the zip file.
+3. Open PowerShell with administrative privileges.
+4. Change to the extracted folder `PS-AutoLab-Env`.
 5. Run PS> .\ [Setup-Host.ps1](./Setup-Host.ps1)
 6. Change to the configuration folder and choose a configuration i.e. c:\Lability\Configuration\<Your Config folder>
 7. Check the Readme.md to find a description of what this config will do.

--- a/Setup-Host.ps1
+++ b/Setup-Host.ps1
@@ -7,6 +7,11 @@ Note: All scripts require WMF 5 or above, and to run from PowerShell using "Run 
 #>
 #Requires -version 5.0
 #Requires -runasadministrator
+
+# Setup Path Variables
+$SourcePath = $PSScriptRoot
+$DestinationPath = "C:\Lability"
+
 Clear-Host
 Write-Host -ForegroundColor Green -Object @"
 
@@ -14,11 +19,11 @@ Write-Host -ForegroundColor Green -Object @"
     * For PowerShell Remoting, Set the host 'TrustedHosts' value to *
     * Install the Lability module from PSGallery
     * Install Hyper-V
-    * Create the C:\Lability folder (DO NOT DELETE)
-    * Copy configurations and resources to C:\Lability
+    * Create the $DestinationPath folder (DO NOT DELETE)
+    * Copy configurations and resources to $DestinationPath
     * You will then need to reboot the host before continuing
 
-    Note! - You may delete the folder c:\PS-AutoLab-Env when this setup finished and the system
+    Note! - You may delete the folder $SourcePath when this setup finished and the system
             has been rebooted.
 
 "@
@@ -62,26 +67,26 @@ If ($HostStatus -eq $False) {
 }
 
 ###### COPY Configs to host machine
-Write-Host -ForegroundColor Cyan -Object "Copying configs to c:\Lability\Configurations" 
-Copy-item -Path C:\PS-AutoLab-Env\Configurations\* -recurse -Destination C:\Lability\Configurations -force
+Write-Host -ForegroundColor Cyan -Object "Copying configs to $DestinationPath\Configurations" 
+Copy-item -Path $SourcePath\Configurations\* -recurse -Destination $DestinationPath\Configurations -force
 
 #### Temp fix until Lability updates version with new media File
 #### Copying new media file manually
-Copy-item -Path C:\PS-AutoLab-Env\media.json -Destination 'C:\Program Files\WindowsPowershell\Modules\Lability\0.10.0\config'
+Copy-item -Path $SourcePath\media.json -Destination 'C:\Program Files\WindowsPowershell\Modules\Lability\0.10.0\config'
 
 
 Write-Host -ForegroundColor Green -Object @"
 
     The Host is about to reboot.
     After the reboot, open Powershell, navigate to a configuration directory
-    C:\Lability\Configuration\<yourconfigfolder>
+    $DestinationPath\Configuration\<yourconfigfolder>
     And run:
     
-    PS C:\Lability\Configuration\<yourconfigfolder>.\Setup-Lab
+    PS $DestinationPath\Configuration\<yourconfigfolder>.\Setup-Lab
 
 "@
 
-Write-Host -ForegroundColor Yellow -Object "Note! - You may delete the folder c:\PS-AutoLab-Env when this setup finished and the system
+Write-Host -ForegroundColor Yellow -Object "Note! - You may delete the folder $SourcePath when this setup finished and the system
             has been rebooted."
 
 Pause


### PR DESCRIPTION
Use $PSScriptRoot as the source directory so that the folder can be extracted anywhere on the system. Also introduce variables for SourcePath and DestinationPath.
