### PR TITLE
Comment out Undeployed Server Validation Tests

### DIFF
--- a/Configurations/Jason-DSC-Env/VMValidate.test.ps1
+++ b/Configurations/Jason-DSC-Env/VMValidate.test.ps1
@@ -114,7 +114,7 @@ It "[S1] Should have a DNS server configuration of 192.168.3.10" {
   $dns.ServerAddresses -contains '192.168.3.10' | Should Be "True"           
 }
 } #S2
-
+<#
 Describe PullServer {
     $PullServer = New-PSSession -VMName PullServer -Credential $cred -ErrorAction SilentlyContinue
 It "[S1] Should accept domain admin credential" {
@@ -130,8 +130,9 @@ It "[S1] Should have a DNS server configuration of 192.168.3.10" {
   $dns.ServerAddresses -contains '192.168.3.10' | Should Be "True"           
 }
 }
+#>
 
-
+<#
 Describe NanoServer {
 
 It "[Nano] Should respond to WSMan requests" { 
@@ -155,7 +156,7 @@ It "[Nano] Should have the DSC package installed" {
 
 }
 }
-
+#>
 
 Describe Cli1 {
 


### PR DESCRIPTION
In the VMConfigurationData.psd1 file, the NanoServer and PullServer are commented out and not configured. As these servers are not deployed, all of the tests to validate these server configurations fail during the Validate-Lab phase causing the system to enter an infinite loop. Either the servers need to be deployed, or the tests need to be removed.